### PR TITLE
Make parent css class name more specific

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,38 +8,38 @@
             padding: 20px;
           }
 
-          .immunization-table {
+          .pediatric-immunizations-schedule {
             font-size: .9em;
             border: 1px solid #ccc;
             width: 100%;
           }
 
-          .immunization-table .disabledCell {
+          .pediatric-immunizations-schedule .disabledCell {
             background-color: lightgray;
           }
 
-          .immunization-table .received {
+          .pediatric-immunizations-schedule .received {
             background-color: lightgreen;
           }
 
-          .immunization-table .due {
+          .pediatric-immunizations-schedule .due {
             background-color: lightyellow;
           }
 
-          .immunization-table .main-cell {
+          .pediatric-immunizations-schedule .main-cell {
             font-weight: bold;
             width: 10%;
           }
 
-          .immunization-table td {
+          .pediatric-immunizations-schedule td {
             text-align: center;
           }
-          .immunization-table td .recommended-age {
+          .pediatric-immunizations-schedule td .recommended-age {
             display: block;
             font-size: .6em;
           }
 
-          .immunization-table td, th {
+          .pediatric-immunizations-schedule td, th {
             border: solid 1px #CCC;
           }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pediatric-immunizations-schedule",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A small js library for displaying a pediatric immunizations schedule based on CDC recommendations.",
   "main": "dist/pediatric-immunizations-chart.js",
   "scripts": {

--- a/src/main.css
+++ b/src/main.css
@@ -1,28 +1,28 @@
-.immunization-table {
+.pediatric-immunizations-table {
   font-size: .9em;
 }
 
-.immunization-table .disabledCell {
+.pediatric-immunizations-table .disabledCell {
   background-color: lightgray;
 }
 
-.immunization-table .received {
+.pediatric-immunizations-table .received {
   background-color: lightgreen;
 }
 
-.immunization-table .due {
+.pediatric-immunizations-table .due {
   background-color: black;
 }
 
-.immunization-table .main-cell {
+.pediatric-immunizations-table .main-cell {
   font-weight: bold;
   width: 10%;
 }
 
-.immunization-table td {
+.pediatric-immunizations-table td {
   text-align: center;
 }
-.immunization-table td .recommended-age {
+.pediatric-immunizations-table td .recommended-age {
   display: block;
   font-size: .6em;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -68,7 +68,7 @@ var ImmunizationTable = function ImmunizationTable(container, options) {
   var table = document.createElement('table'),
       tbody = document.createElement('tbody');
 
-  table.className = 'immunization-table';
+  table.className = 'pediatric-immunizations-schedule';
   table.appendChild(tbody);
 
   this.vacSched.immunizations.map((vac, idx) => {


### PR DESCRIPTION
Use 'pediatric-immunizations-schedule' instead of the more general
'immunization-table'. This will help avoid conflicts w/ existing
elements.

Also includes version bump commit from previous documentation patch.